### PR TITLE
Ensure correct line termination of .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
If the repo is cloned to a Windows PC, and the files then copied over to the Pi, the scripts will not run due to the files having a line termination character different to that which Linux expects.